### PR TITLE
feat(#2): implement routing architecture with layout and lazy-load views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1988,6 +1989,14 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3323,6 +3332,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3458,6 +3503,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,28 @@
+import { Routes, Route } from "react-router-dom";
+import { Suspense, lazy } from "react";
+
+import Layout from "./layout/Layout";
+
+const Dashboard = lazy(() => import("./pages/Dashboard"));
+const MapView = lazy(() => import("./pages/MapView"));
+const AnalyticsView = lazy(() => import("./pages/AnalyticsView"));
+
 const App = () => {
-  return (
-    <div className="min-h-screen bg-blue-50 p-6">
-      <h1 className="text-3xl font-bold text-blue-800">Tailwind is working!</h1>
+  const loadingUI = () => (
+    <div className="flex items-center justify-center h-screen">
+      <div className="loader"></div>
     </div>
+  );
+  return (
+    <Suspense fallback={loadingUI()}>
+      <Routes>
+        <Route path="/" element={<Layout />}>
+          <Route index element={<Dashboard />} />
+          <Route path="map" element={<MapView />} />
+          <Route path="analytics" element={<AnalyticsView />} />
+        </Route>
+      </Routes>
+    </Suspense>
   );
 };
 

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,0 +1,18 @@
+import { Outlet } from "react-router-dom";
+
+const Layout = () => {
+  return (
+    <div className="flex flex-col h-screen">
+      {/* Sidebar */}
+      <aside className="w-64 bg-gray-100 p-4">
+        <h2 className="text-xl font-bold">Sidebar</h2>
+      </aside>
+      {/* Main content */}
+      <main className="flex-1 p-6">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App.tsx";
+import "./index.css";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </StrictMode>
+);

--- a/src/pages/AnalyticsView.tsx
+++ b/src/pages/AnalyticsView.tsx
@@ -1,0 +1,5 @@
+const AnalyticsView = () => {
+  return <div>AnalyticsView</div>;
+};
+
+export default AnalyticsView;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,5 @@
+const Dashboard = () => {
+  return <div>Dashboard</div>;
+};
+
+export default Dashboard;

--- a/src/pages/MapView.tsx
+++ b/src/pages/MapView.tsx
@@ -1,0 +1,5 @@
+const MapView = () => {
+  return <div>MapView</div>;
+};
+
+export default MapView;


### PR DESCRIPTION
## 📝 Summary

Provide a concise description of what this PR accomplishes. Link to relevant tickets: [#3](https://github.com/vneilly/live-dashboard-demo/issues/3)

Established routing infrastructure using `react-router-dom` v6, including a shared layout wrapper with nested routes and lazy-loaded page views. This mimics Next.js layout behavior and sets the foundation for future features.

---

## ✅ Deliverables

- [x] Installed `react-router-dom`
- [x] Wrapped app in `BrowserRouter` in `main.tsx`
- [x] Created `Layout.tsx` with sidebar and `<Outlet />`
- [x] Created lazy-loaded page components: `Dashboard`, `MapView`, `AnalyticsView`
- [x] Defined nested routes under `Layout` with `Suspense` fallback
- [x] Verified routing and layout behavior via manual navigation

---

## 🕒 LOE / Notes

Estimated 2.5 hours  
Confirmed route nesting and layout injection via `<Outlet />`  
Used `React.Suspense` with custom loading UI for lazy route fallback

---

## 🎯 Related Ticket

Closes [#3 ]

---

## 🛠️ Changes Made

- [X ] Feature implementation
- [ ] Bug fix
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Test addition/modification
- [ ] Configuration change
- [ ] Dependencies update

---

## Notes

> Include any relevant timing, decisions, trade-offs, or issues encountered during this PR.

---
