### PR TITLE
feat(context): integrate AppProvider and global context state

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,0 +1,26 @@
+import { useReducer } from "react";
+import type { ReactNode } from "react";
+import type { AppState } from "./types";
+import { AppContext, appReducer } from "./AppHelpers";
+
+const initialState: AppState = {
+  equipment: [],
+  networkNodes: [],
+  filters: {
+    type: null,
+    status: null,
+  },
+  lastUpdated: Date.now(), // Initialize with the current timestamp
+};
+
+export const AppProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [state, dispatch] = useReducer(appReducer, initialState);
+
+  return (
+    <AppContext.Provider value={{ state, dispatch }}>
+      {children}
+    </AppContext.Provider>
+  );
+};

--- a/src/context/AppHelpers.ts
+++ b/src/context/AppHelpers.ts
@@ -1,0 +1,48 @@
+import { createContext, useContext } from "react";
+
+import type { AppState, AppAction } from "./types";
+
+interface AppContextType {
+  state: AppState;
+  dispatch: React.Dispatch<AppAction>;
+}
+
+export const appReducer = (state: AppState, action: AppAction): AppState => {
+  switch (action.type) {
+    case "SET_EQUIPMENT":
+      return {
+        ...state,
+        equipment: action.payload,
+      };
+    case "SET_NODES":
+      return {
+        ...state,
+        networkNodes: action.payload,
+      };
+    case "SET_FILTERS":
+      return {
+        ...state,
+        filters: {
+          ...state.filters,
+          ...action.payload,
+        },
+      };
+    case "UPDATE_TIMESTAMP":
+      return {
+        ...state,
+        lastUpdated: action.payload,
+      };
+    default:
+      return state;
+  }
+};
+
+export const AppContext = createContext<AppContextType | undefined>(undefined);
+
+export const useAppContext = (): AppContextType => {
+  const context = useContext(AppContext);
+  if (!context) {
+    throw new Error("useAppContext must be used within an AppProvider");
+  }
+  return context;
+};

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -1,0 +1,36 @@
+export interface AppState {
+  equipment: EquipmentItem[];
+  networkNodes: NetworkNode[];
+  filters: {
+    type: string | null;
+    status: string | null;
+  };
+  lastUpdated: number; // Timestamp of the last update
+}
+
+export interface EquipmentItem {
+  id: number;
+  name: string;
+  status: "Available" | "In Use" | "Maintenance"; // Example statuses
+  location: string; // Location of the equipment
+  coords: [number, number]; // Timestamp of the last update
+}
+
+export interface NetworkNode {
+  id: string;
+  type: "4G" | "5G";
+  status: "Online" | "Offline"; // Example statuses
+  region: string; // Region where the node is located
+  coords: [number, number]; // Coordinates of the node
+}
+
+export type AppAction =
+  | { type: "SET_EQUIPMENT"; payload: EquipmentItem[] }
+  | { type: "SET_NODES"; payload: NetworkNode[] }
+  | { type: "SET_FILTERS"; payload: FilterPayload }
+  | { type: "UPDATE_TIMESTAMP"; payload: number };
+
+export interface FilterPayload {
+  type: string | null;
+  status: string | null;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,16 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { AppProvider } from "./context/AppContext.tsx";
 import App from "./App.tsx";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <AppProvider>
+        <App />
+      </AppProvider>
     </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## 📝 Description
This PR introduces the global `AppContext` and `AppProvider` using React Context + useReducer to manage shared state for the application. It sets the foundation for centralized app-wide state handling, including equipment, network nodes, filters, and last update timestamp.

[#5 ](https://github.com/vneilly/live-dashboard-demo/issues/5)

- Created AppProvider using React Context API and useReducer
- Defined AppState, AppAction, and reducer logic for shared state
- Wrapped the application with AppProvider in main.tsx to enable global context


---

## 🎯 Related Ticket

Closes #5

---

## 🛠️ Changes Made

- [X] Feature implementation
- [ ] Bug fix
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Test addition/modification
- [ ] Configuration change
- [ ] Dependencies update

---

## Notes

- Verified the app compiles and runs with no runtime or lint errors
- Confirmed Tailwind styles render
- Confirmed `AppProvider` loads without crashing and prepares context for upcoming usage


---
